### PR TITLE
Refine: Display only engagement rate in Instagram engagement graphs

### DIFF
--- a/src/components/dashboard/EngagementSection.tsx
+++ b/src/components/dashboard/EngagementSection.tsx
@@ -118,24 +118,10 @@ const EngagementSection: React.FC<EngagementSectionProps> = ({
       labels: brandData.map(data => data?.brand),
       datasets: [
         {
-          label: 'Avg. Likes per Image Post',
-          data: brandData.map(data => data?.avgLikes),
-          backgroundColor: vibrantColors[0],
-          borderColor: vibrantColors[0].replace('0.8', '1'),
-          borderWidth: 1,
-        },
-        {
-          label: 'Avg. Comments per Image Post',
-          data: brandData.map(data => data?.avgComments),
-          backgroundColor: vibrantColors[1],
-          borderColor: vibrantColors[1].replace('0.8', '1'),
-          borderWidth: 1,
-        },
-        {
           label: 'Image Engagement Rate',
           data: brandData.map(data => data?.engagementRate),
-          backgroundColor: vibrantColors[2],
-          borderColor: vibrantColors[2].replace('0.8', '1'),
+          backgroundColor: vibrantColors[0], // Updated color
+          borderColor: vibrantColors[0].replace('0.8', '1'), // Updated color
           borderWidth: 1,
         }
       ]
@@ -242,24 +228,10 @@ const EngagementSection: React.FC<EngagementSectionProps> = ({
         labels: brandData.map(data => data?.brand),
         datasets: [
           {
-            label: 'Avg. Likes per Video Post',
-            data: brandData.map(data => data?.metrics[0].value),
-            backgroundColor: vibrantColors[2],
-            borderColor: vibrantColors[2].replace('0.8', '1'),
-            borderWidth: 1,
-          },
-          {
-            label: 'Avg. Comments per Video Post',
-            data: brandData.map(data => data?.metrics[1].value),
-            backgroundColor: vibrantColors[3],
-            borderColor: vibrantColors[3].replace('0.8', '1'),
-            borderWidth: 1,
-          },
-          {
             label: 'Video Engagement Rate (%)',
-            data: brandData.map(data => data?.metrics[2].value),
-            backgroundColor: vibrantColors[4],
-            borderColor: vibrantColors[4].replace('0.8', '1'),
+            data: brandData.map(data => data?.metrics[2].value), // This was already correct for the rate
+            backgroundColor: vibrantColors[0], // Updated color
+            borderColor: vibrantColors[0].replace('0.8', '1'), // Updated color
             borderWidth: 1,
           }
         ]


### PR DESCRIPTION
This commit updates the "Instagram Image Post Engagement" and "Instagram Video Post Engagement" graphs within the `EngagementSection.tsx` component to display only the respective engagement rates, removing other metrics like average likes and comments from these specific charts.

Modifications in `src/components/dashboard/EngagementSection.tsx`:
- For `instagramImageEngagementData`:
  - Removed the datasets for "Avg. Likes per Image Post" and "Avg. Comments per Image Post".
  - The chart now solely displays "Image Engagement Rate" (calculated as total likes + total comments for image/sidecar posts).
- For `videoEngagementData` (when platform is Instagram):
  - Removed the datasets for "Avg. Likes per Video Post" and "Avg. Comments per Video Post".
  - The chart now solely displays "Video Engagement Rate (%)" (calculated as ((likes + comments) / views) * 100 for video posts).
- Updated the `backgroundColor` for the single remaining dataset in each chart for visual consistency.

This change addresses your feedback to simplify these specific graphs by focusing exclusively on the engagement rate metric.