### PR TITLE
Fix: Update Header and Instagram KPI calculations

### DIFF
--- a/src/components/dashboard/DashboardOverview.tsx
+++ b/src/components/dashboard/DashboardOverview.tsx
@@ -256,11 +256,27 @@ const DashboardOverview: React.FC = () => {
     }
 
     // Calculate averages and rates for Nordstrom
+    // General averages for all Instagram posts
     if (totalInstagramPosts > 0) {
-      avgInstagramLikes = totalInstagramLikes / totalInstagramPosts;
-      avgInstagramComments = totalInstagramComments / totalInstagramPosts;
-      instagramEngagementRate = ((totalInstagramLikes + totalInstagramComments) / totalInstagramPosts) / 100;
+      avgInstagramLikes = totalInstagramLikes / totalInstagramPosts; // Remains average for all posts
+      avgInstagramComments = parseFloat((totalInstagramComments / totalInstagramPosts).toFixed(1)); // Remains average for all posts
+    } else {
+      avgInstagramLikes = 0;
+      avgInstagramComments = 0.0;
     }
+
+    // Instagram Video Engagement Rate for Nordstrom
+    const nordstromInstagramVideoPosts = socialData.instagram['Nordstrom']?.posts.filter(p => (p as InstagramPost).mediaType === 'Video') as InstagramPost[] || [];
+    let nordstromVideoLikes = 0;
+    let nordstromVideoComments = 0;
+    let nordstromVideoViews = 0;
+    if (nordstromInstagramVideoPosts.length > 0) {
+      nordstromVideoLikes = nordstromInstagramVideoPosts.reduce((sum, p) => sum + (p.likesCount || 0), 0);
+      nordstromVideoComments = nordstromInstagramVideoPosts.reduce((sum, p) => sum + (p.commentsCount || 0), 0);
+      nordstromVideoViews = nordstromInstagramVideoPosts.reduce((sum, p) => sum + (p.videoViewCount || 0), 0);
+    }
+    const rawNordstromVideoER = nordstromVideoViews > 0 ? ((nordstromVideoLikes + nordstromVideoComments) / nordstromVideoViews) * 100 : 0;
+    instagramEngagementRate = parseFloat(rawNordstromVideoER.toFixed(1));
     
     if (totalTikTokPosts > 0) {
       avgTikTokViews = totalTikTokViews / totalTikTokPosts;
@@ -270,11 +286,27 @@ const DashboardOverview: React.FC = () => {
     }
     
     // Calculate averages and rates for competitor
+    // General averages for all Instagram posts for competitor
     if (competitorInstagramPosts > 0) {
-      competitorAvgInstagramLikes = competitorInstagramLikes / competitorInstagramPosts;
-      competitorAvgInstagramComments = competitorInstagramComments / competitorInstagramPosts;
-      competitorInstagramEngagementRate = ((competitorInstagramLikes + competitorInstagramComments) / competitorInstagramPosts) / 100;
+      competitorAvgInstagramLikes = competitorInstagramLikes / competitorInstagramPosts; // Remains average for all posts
+      competitorAvgInstagramComments = parseFloat((competitorInstagramComments / competitorInstagramPosts).toFixed(1)); // Remains average for all posts
+    } else {
+      competitorAvgInstagramLikes = 0;
+      competitorAvgInstagramComments = 0.0;
     }
+
+    // Instagram Video Engagement Rate for Competitor
+    const competitorInstagramVideoPosts = socialData.instagram[selectedCompetitor]?.posts.filter(p => (p as InstagramPost).mediaType === 'Video') as InstagramPost[] || [];
+    let competitorVideoLikes = 0;
+    let competitorVideoComments = 0;
+    let competitorVideoViews = 0;
+    if (competitorInstagramVideoPosts.length > 0) {
+      competitorVideoLikes = competitorInstagramVideoPosts.reduce((sum, p) => sum + (p.likesCount || 0), 0);
+      competitorVideoComments = competitorInstagramVideoPosts.reduce((sum, p) => sum + (p.commentsCount || 0), 0);
+      competitorVideoViews = competitorInstagramVideoPosts.reduce((sum, p) => sum + (p.videoViewCount || 0), 0);
+    }
+    const rawCompetitorVideoER = competitorVideoViews > 0 ? ((competitorVideoLikes + competitorVideoComments) / competitorVideoViews) * 100 : 0;
+    competitorInstagramEngagementRate = parseFloat(rawCompetitorVideoER.toFixed(1));
     
     if (competitorTikTokPosts > 0) {
       competitorAvgTikTokViews = competitorTikTokViews / competitorTikTokPosts;

--- a/src/components/dashboard/InstagramEngagementCard.tsx
+++ b/src/components/dashboard/InstagramEngagementCard.tsx
@@ -25,27 +25,27 @@ const InstagramEngagementCard: React.FC<InstagramEngagementCardProps> = ({
     >
       <div className="flex justify-between items-start">
         <div>
-          <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Engagement Rate (Insta)</p>
-          <h3 className="text-3xl font-bold text-nordstrom-blue mt-1">{(instagramEngagementRate * 100).toFixed(2)}%</h3>
+          <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Video Engagement Rate (Insta)</p>
+          <h3 className="text-3xl font-bold text-nordstrom-blue mt-1">{(instagramEngagementRate).toFixed(1)}%</h3> {/* Value is already a percentage, display with 1 decimal */}
         </div>
         <BiIcons.BiTrendingUp className="text-3xl text-nordstrom-blue/70 dark:text-nordstrom-blue/60" />
       </div>
       <div className="mt-4 text-xs text-gray-600 dark:text-gray-300">
         <div className="flex justify-between">
           <p>Nordstrom</p>
-          <p className="font-medium">{(instagramEngagementRate * 100).toFixed(2)}%</p>
+          <p className="font-medium">{(instagramEngagementRate).toFixed(1)}%</p>
         </div>
         <div className="flex justify-between mt-1">
           <p>{selectedCompetitor}</p>
-          <p className="font-medium">{(competitorInstagramEngagementRate * 100).toFixed(2)}%</p>
+          <p className="font-medium">{(competitorInstagramEngagementRate).toFixed(1)}%</p>
         </div>
         {instagramEngagementRate > 0 && competitorInstagramEngagementRate > 0 && (
           <div className="mt-2 pt-2 border-t border-gray-200 dark:border-gray-600">
             <p>
               {instagramEngagementRate > competitorInstagramEngagementRate 
-                ? `Nordstrom has ${((instagramEngagementRate - competitorInstagramEngagementRate) * 100).toFixed(2)}% higher engagement.`
+                ? `Nordstrom has ${(instagramEngagementRate - competitorInstagramEngagementRate).toFixed(1)}% higher engagement.`
                 : instagramEngagementRate < competitorInstagramEngagementRate
-                  ? `${selectedCompetitor} has ${((competitorInstagramEngagementRate - instagramEngagementRate) * 100).toFixed(2)}% higher engagement.`
+                  ? `${selectedCompetitor} has ${(competitorInstagramEngagementRate - instagramEngagementRate).toFixed(1)}% higher engagement.`
                   : 'Equal engagement rates.'}
             </p>
           </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -131,24 +131,17 @@ const Header: React.FC<HeaderProps> = () => {
               </div>
             )}
           </div>
-          <p className="text-xs text-gray-500 flex items-center"> {/* Adjusted text color */}
-            <FaIcons.FaCalendarAlt className="mr-1" />
-            Last updated: {getLastFetchedTime()}
-            <span className="ml-2 text-xs text-nordstrom-blue cursor-pointer hover:underline" onClick={handleRefresh}> {/* Adjusted text color */}
-              Refresh now
-            </span>
-          </p>
+          {/* "Last updated" text and "Refresh now" span removed as per subtask */}
         </div>
 
         {/* Desktop Menu Items */}
-        {/* TODO: Restyle these buttons and dropdowns for a bg-white header. Current styling is for dark background. */}
         <div className="hidden lg:flex items-center space-x-3">
           {/* Dark Mode Toggle */}
           <motion.button
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
             onClick={toggleDarkMode}
-            className={`p-2 rounded-full transition-colors duration-150 ${darkMode ? 'hover:bg-gray-700 text-gray-300 hover:text-yellow-400' : 'hover:bg-gray-100 text-gray-600 hover:text-nordstrom-blue'} focus:outline-none focus:ring-2 focus:ring-nordstrom-blue`}
+            className={`p-2 rounded-full transition-colors duration-150 ${darkMode ? 'hover:bg-gray-700 text-gray-300 hover:text-yellow-400' : 'hover:bg-gray-100 text-gray-500 hover:text-[#004170]'} focus:outline-none focus:ring-2 focus:ring-[#004170]`}
             aria-label="Toggle dark mode"
             title="Toggle dark mode"
           >
@@ -163,7 +156,7 @@ const Header: React.FC<HeaderProps> = () => {
                 whileHover={{ scale: 1.02 }}
                 whileTap={{ scale: 0.98 }}
                 onClick={() => setActiveFilterSection(activeFilterSection === 'months' ? null : 'months')}
-                className="bg-transparent border border-[#004170] text-[#004170] hover:bg-[#004170] hover:text-white rounded-md px-3 py-1.5 text-sm font-medium transition-colors duration-150 flex items-center filter-button group"
+                className="bg-transparent border border-[#004170] text-[#004170] hover:bg-[#004170] hover:text-white rounded-lg px-3 py-1.5 text-sm font-medium transition-colors duration-150 flex items-center filter-button group"
               >
                 <FaIcons.FaCalendarAlt className="mr-2 text-[#004170] group-hover:text-white transition-colors duration-150" size={14} />
                 <span>Month: {filterOptions.selectedMonth}</span>
@@ -206,7 +199,7 @@ const Header: React.FC<HeaderProps> = () => {
                 whileHover={{ scale: 1.02 }}
                 whileTap={{ scale: 0.98 }}
                 onClick={() => setActiveFilterSection(activeFilterSection === 'brands' ? null : 'brands')}
-                className="bg-transparent border border-[#004170] text-[#004170] hover:bg-[#004170] hover:text-white rounded-md px-3 py-1.5 text-sm font-medium transition-colors duration-150 flex items-center filter-button group"
+                className="bg-transparent border border-[#004170] text-[#004170] hover:bg-[#004170] hover:text-white rounded-lg px-3 py-1.5 text-sm font-medium transition-colors duration-150 flex items-center filter-button group"
               >
                 <FaIcons.FaStore className="mr-2 text-[#004170] group-hover:text-white transition-colors duration-150" size={14} />
                 <span>Brands ({selectedBrands.length})</span>
@@ -252,7 +245,7 @@ const Header: React.FC<HeaderProps> = () => {
                 whileHover={{ scale: 1.02 }}
                 whileTap={{ scale: 0.98 }}
                 onClick={() => setActiveFilterSection(activeFilterSection === 'platform' ? null : 'platform')}
-                className="bg-transparent border border-[#004170] text-[#004170] hover:bg-[#004170] hover:text-white rounded-md px-3 py-1.5 text-sm font-medium transition-colors duration-150 flex items-center filter-button group"
+                className="bg-transparent border border-[#004170] text-[#004170] hover:bg-[#004170] hover:text-white rounded-lg px-3 py-1.5 text-sm font-medium transition-colors duration-150 flex items-center filter-button group"
               >
                 <FaIcons.FaShareAlt className="mr-2 text-[#004170] group-hover:text-white transition-colors duration-150" size={14} />
                 <span>Platforms</span>
@@ -293,47 +286,17 @@ const Header: React.FC<HeaderProps> = () => {
                 </div>
               )}
             </div>
-            
-            {/* Reset filters button */}
-            <motion.button
-              whileHover={{ scale: 1.02 }}
-              whileTap={{ scale: 0.98 }}
-              onClick={() => {
-                setFilterOptions({
-                  ...initialFilterOptions,
-                  selectedMonth: 'All (Feb-May)'
-                });
-                setSelectedBrands(['Nordstrom']);
-                refreshData();
-              }}
-              className="bg-transparent border border-[#004170] text-[#004170] hover:bg-[#004170] hover:text-white rounded-md px-3 py-1.5 text-sm font-medium transition-colors duration-150 flex items-center group"
-              title="Reset all filters"
-            >
-              <BiIcons.BiReset className="mr-1 text-[#004170] group-hover:text-white transition-colors duration-150" />
-              <span>Reset</span>
-            </motion.button>
+            {/* "Reset filters" button removed */}
           </div>
 
-          {/* Main Refresh Button */}
-          <motion.button
-            whileHover={{ scale: 1.02 }}
-            whileTap={{ scale: 0.98 }}
-            animate={refreshClicked ? { rotate: 360 } : {}}
-            transition={{ duration: 0.5 }}
-            onClick={handleRefresh}
-            disabled={isLoading}
-            className={`bg-[#004170] hover:bg-[#003459] text-white px-3 py-1.5 text-sm font-medium rounded-md flex items-center transition-colors duration-150 ${isLoading ? 'opacity-70 cursor-not-allowed' : ''}`}
-          >
-            <BiIcons.BiRefresh className={`mr-2 ${isLoading ? 'animate-spin' : ''}`} size={20} />
-            <span>{isLoading ? 'Refreshing...' : 'Refresh Data'}</span>
-          </motion.button>
+          {/* "Refresh Data" button removed */}
           
           {/* Export Button */}
           <div className="relative">
             <motion.button
               whileHover={{ scale: 1.02 }}
               whileTap={{ scale: 0.98 }}
-              className="bg-transparent border border-[#004170] text-[#004170] hover:bg-[#004170] hover:text-white rounded-md px-3 py-1.5 text-sm font-medium transition-colors duration-150 flex items-center group"
+              className="bg-transparent border border-[#004170] text-[#004170] hover:bg-[#004170] hover:text-white rounded-lg px-3 py-1.5 text-sm font-medium transition-colors duration-150 flex items-center group"
               onClick={() => {
                 // Generate export data for selected brands
                 const exportData = {


### PR DESCRIPTION
This commit addresses specific feedback to modify the application header and adjust calculations for certain Instagram Key Performance Indicators (KPIs).

**Header Changes (`src/components/layout/Header.tsx`):**
- Removed the "Last updated" text display.
- Removed the "Reset filters" button.
- Removed the "Main Refresh Data" button.

**KPI Changes (`src/components/dashboard/DashboardOverview.tsx` and `src/components/dashboard/InstagramEngagementCard.tsx`):**
1.  **Instagram Comments KPI:**
    - The average Instagram comments for both Nordstrom (`avgInstagramComments`) and the competitor (`competitorAvgInstagramComments`) displayed in the KPI card are now formatted to one decimal place.
2.  **Instagram Engagement Rate KPI:**
    - This KPI is now specifically calculated based on **video posts only**.
    - The formula `((likesCount + commentsCount) / videoViewCount) * 100` is applied to the filtered video posts.
    - The final engagement rate is formatted to one decimal place.
    - The title of the `InstagramEngagementCard.tsx` has been updated to "Video Engagement Rate (Insta)" to reflect this change.
    - The value display in the card was also adjusted to correctly show the percentage with one decimal.

These changes refine the information presented in the header and provide more specific and accurately formatted Instagram performance metrics as per your requirements.